### PR TITLE
updated examples of amount & vat to clarify what they are（請求書の明細行の金額と消費税の意味を明確にさせるため、exampleの数字を修正）

### DIFF
--- a/_sdk_compatible/open-api-3/api-schema.yml
+++ b/_sdk_compatible/open-api-3/api-schema.yml
@@ -16789,7 +16789,7 @@ components:
                 type: string
               amount:
                 description: 金額
-                example: 108000
+                example: 100000
                 maximum: 9223372036854775807
                 minimum: -9223372036854775808
                 type: integer
@@ -16923,7 +16923,7 @@ components:
                 type: number
               vat:
                 description: 消費税額
-                example: 8000
+                example: 10000
                 type: integer
             required:
               - account_item_id

--- a/v2020_06_15/open-api-3/api-schema.json
+++ b/v2020_06_15/open-api-3/api-schema.json
@@ -34556,12 +34556,12 @@
                       "minimum": -9223372036854775808,
                       "maximum": 9223372036854775807,
                       "description": "金額",
-                      "example": 108000
+                      "example": 100000
                     },
                     "vat": {
                       "type": "integer",
                       "description": "消費税額",
-                      "example": 8000
+                      "example": 10000
                     },
                     "reduced_vat": {
                       "type": "boolean",

--- a/v2020_06_15/open-api-3/api-schema.yml
+++ b/v2020_06_15/open-api-3/api-schema.yml
@@ -19401,7 +19401,7 @@ components:
                     type: string
                   amount:
                     description: 金額
-                    example: 108000
+                    example: 100000
                     format: int64
                     maximum: 9223372036854775807
                     minimum: -9223372036854775808
@@ -19534,7 +19534,7 @@ components:
                     type: number
                   vat:
                     description: 消費税額
-                    example: 8000
+                    example: 10000
                     type: integer
                 required:
                 - account_item_id


### PR DESCRIPTION
freee Developer Communityがなくなってしまい質問ができなかったため、いきなりプルリクエストで失礼します。

ドキュメント上の例が
```
amount: 108000
vat: 8000
```

となっているため、先日、amountが税込み金額と思って開発（税抜金額を出すために `amount - vat` を計算）したところ、実際はamountに税抜き金額が入っていました。

そもそもamountが税抜きに固定なのか、freee利用事業所の設定によっては税込金額が入っていることがあるのか不明なのですが（弊社は税抜設定で利用しているようです）、少なくともAPIドキュメント上の現在の例はミスリーディングな数字（amountが税込みにしか見えない）になっています。
exampleだけでなくdescriptionに `金額（税抜き）` または `金額（請求書全体が税込み設定であれば税込み、税抜き設定であれば税抜き）` のように記載も検討していただけると助かります :pray: 

よろしくお願い致します。