### PR TITLE
invoiceResponseの例の値を変更

### DIFF
--- a/_sdk_compatible/open-api-3/api-schema.yml
+++ b/_sdk_compatible/open-api-3/api-schema.yml
@@ -16127,7 +16127,6 @@ components:
 
                 <a href="https://support.freee.co.jp/hc/ja/articles/203318410#1-2" target="_blank">見積書・納品書を納品書・請求書に変換する</a><br>
                 <a href="https://support.freee.co.jp/hc/ja/articles/209076226" target="_blank">複数の見積書・納品書から合算請求書を作成する</a><br>
-              example: 1
               items:
                 description: 関連する見積書ID
                 example: 3

--- a/_sdk_compatible/open-api-3/api-schema.yml
+++ b/_sdk_compatible/open-api-3/api-schema.yml
@@ -15746,6 +15746,7 @@ components:
               type: string
             deal_id:
               description: 取引ID (invoice_statusがsubmitted, unsubmittedの時IDが表示されます)
+              example: 1
               maximum: 2147483647
               minimum: 1
               nullable: true

--- a/v2020_06_15/open-api-3/api-schema.json
+++ b/v2020_06_15/open-api-3/api-schema.json
@@ -34812,7 +34812,6 @@
               "related_quotation_ids": {
                 "type": "array",
                 "description": "関連する見積書ID(配列)<br>\n下記で作成したものが該当します。\n\n<a href=\"https://support.freee.co.jp/hc/ja/articles/203318410#1-2\" target=\"_blank\">見積書・納品書を納品書・請求書に変換する</a><br>\n<a href=\"https://support.freee.co.jp/hc/ja/articles/209076226\" target=\"_blank\">複数の見積書・納品書から合算請求書を作成する</a><br>\n",
-                "example": 1,
                 "items": {
                   "type": "integer",
                   "minimum": 1,

--- a/v2020_06_15/open-api-3/api-schema.json
+++ b/v2020_06_15/open-api-3/api-schema.json
@@ -34559,6 +34559,7 @@
                 "minimum": 1,
                 "maximum": 2147483647,
                 "description": "取引ID (invoice_statusがsubmitted, unsubmittedの時IDが表示されます)",
+                "example": 1,
                 "nullable": true
               },
               "invoice_contents": {

--- a/v2020_06_15/open-api-3/api-schema.yml
+++ b/v2020_06_15/open-api-3/api-schema.yml
@@ -20021,7 +20021,6 @@ components:
 
                 <a href="https://support.freee.co.jp/hc/ja/articles/203318410#1-2" target="_blank">見積書・納品書を納品書・請求書に変換する</a><br>
                 <a href="https://support.freee.co.jp/hc/ja/articles/209076226" target="_blank">複数の見積書・納品書から合算請求書を作成する</a><br>
-              example: 1
               items:
                 description: 関連する見積書ID
                 example: 3

--- a/v2020_06_15/open-api-3/api-schema.yml
+++ b/v2020_06_15/open-api-3/api-schema.yml
@@ -19640,6 +19640,7 @@ components:
               type: string
             deal_id:
               description: 取引ID (invoice_statusがsubmitted, unsubmittedの時IDが表示されます)
+              example: 1
               maximum: 2147483647
               minimum: 1
               nullable: true


### PR DESCRIPTION
APIドキュメントの請求書系レスポンスで、deal_idが0となっていました。deal_idは1以上の値が望まれているので、このままテストデータを作成すると、エラーとなってしまいます。
そこで、例の値を1になるように調整しました。

### 追記
同レスポンス、related_quotation_idsの値が配列型ですが`1`と数値になっていたので、配列型になるように調整しました。

お手数ですが、ご確認お願いします。