### PR TITLE
Add undocumented `group_id` to account item response

### DIFF
--- a/v2020_06_15/open-api-3/api-schema.json
+++ b/v2020_06_15/open-api-3/api-schema.json
@@ -20350,6 +20350,14 @@
                 "example": "売掛金",
                 "nullable": true
               },
+              "group_id": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 2147483647,
+                "description": "決算書表示項目ID（小カテゴリー）",
+                "example": 1234,
+                "nullable": true
+              },
               "corresponding_income_name": {
                 "type": "string",
                 "description": "収入取引相手勘定科目名",


### PR DESCRIPTION
Add undocumented `group_id` to account item response.

```json
{
  "account_items": [
    {
      "id": 4567,
      "name": "その他有価証券評価差額金",
      "tax_code": 2,
      "shortcut": "SONOTAYU",
      "shortcut_num": "123",
      "account_category_id": 234,
      "corresponding_income_name": "未収入金",
      "corresponding_expense_name": "未払金",
      "corresponding_income_id": 1234,
      "corresponding_expense_id": 2345,
      "group_name": "その他有価証券評価差額金",
      "group_id": 3456, // undocumented!
      "default_tax_code": 2,
      "account_category": "他有価証券評価差額金",
      "categories": [
        "負債及び純資産",
        "純資産",
        "評価・換算差額等",
        "他有価証券評価差額金"
      ],
      "available": true,
      "walletable_id": null
    }
  ]
}
```